### PR TITLE
return new lists of the first and last n items in a list

### DIFF
--- a/src/main/java/minimalisp/Lisp.java
+++ b/src/main/java/minimalisp/Lisp.java
@@ -190,12 +190,30 @@ public class Lisp {
   public static <T> T first(List<T> list) {
     return list == null || list.isEmpty() ? null : list.get(0);
   }
+  
+  /** 
+   * Returns a list of the first n items in the list.
+   */
+  public static <T> List<T> head(List<T> list, int n) {
+    if (list == null) return null;
+    if (list.size() < n) return copy(list);
+    return list.subList(0, n); 
+  }
 
   /**
    * Returns the last item in the list.
    */
   public static <T> T last(List<T> list) {
     return list == null || list.isEmpty() ? null : list.get(list.size() - 1);
+  }
+  
+  /**
+   * Returns a list of the last n items in the list
+   */
+  public static <T> List<T> tail(List<T> list, int n) {
+    if (list == null) return null;
+    if (list.size() < n) return copy(list);    
+    return list.subList((list.size() - n), list.size());
   }
 
   /**

--- a/src/test/java/minimalisp/LispTest.java
+++ b/src/test/java/minimalisp/LispTest.java
@@ -101,10 +101,21 @@ public class LispTest extends Lisp {
     assertNull(last(list()));
     assertNull(last(null));
   }
+  
+  @Test public void testHead() {
+    assertNull(head(null, 3));
+    assertEquals(list(1, 2), head(list(1, 2), 3));
+    assertEquals(list(1, 2, 3), head(list(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3));
+  }
+  
+  @Test public void testTail() {
+    assertEquals(list(8, 9, 10), tail(list(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 3));
+    assertEquals(list(1, 2), tail(list(1, 2), 3));
+    assertNull(tail(null, 3));
+  }
 
   @Test public void testRest() {
     assertEquals(list("B", "C", "D"), rest(list("A", "B", "C", "D")));
-    
     assertEquals(list(), rest(list()));
     assertNull(rest(null));
   }


### PR DESCRIPTION
Added `head` and `tail` functions.
These could have been done as overloaded `first` and `last` functions. However, the behaviour is slightly different around empty lists.

i.e.
```
head(list(), 1); // => returns an empty list
first(list()); // => returns null
```