### PR TITLE
Return map except keys

### DIFF
--- a/src/main/java/minimalisp/Lisp.java
+++ b/src/main/java/minimalisp/Lisp.java
@@ -183,6 +183,15 @@ public class Lisp {
   @SafeVarargs public static <T> Set<T> set(T... objects) {
     return hashSet(list(objects));
   }
+  
+  /**
+   * Returns a new Map excluding the entries for the passed Map keys
+   */
+  @SafeVarargs public static <K, V> Map<K, V> except(Map<K, V> map, K... keys){
+    Map<K, V> copy = new LinkedHashMap<K, V>(map);
+    list(keys).forEach(key -> copy.remove(key));
+    return copy;
+  }
 
   /**
    * Returns the first item in the list.

--- a/src/test/java/minimalisp/LispTest.java
+++ b/src/test/java/minimalisp/LispTest.java
@@ -138,6 +138,12 @@ public class LispTest extends Lisp {
             list("B", "D")));
   }
   
+  @Test public void testExcept() {
+    assertEquals(map("B", 2, "C", 3, "D", 4), except(map("A", 1, "B", 2, "C", 3, "D", 4), "A"));
+    assertEquals(map("A", 1, "B", 2, "C", 3, "D", 4), except(map("A", 1, "B", 2, "C", 3, "D", 4), "E"));    
+    assertEquals(map("B", 2, "C", 3), except(map("A", 1, "B", 2, "C", 3, "D", 4), "A", "D", "E"));
+  }
+  
   @Test public void testZip_uneven() {
     assertEquals(
         list(


### PR DESCRIPTION
Return new map with contents of supplied map except the entries for the supplied keys.

```
assertEquals(
  map("B", 2, "C", 3), 
  except(map("A", 1, "B", 2, "C", 3, "D", 4), "A", "D", "E"));
```