### PR TITLE
Reverse parameters

### DIFF
--- a/src/main/java/minimalisp/Lisp.java
+++ b/src/main/java/minimalisp/Lisp.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/main/java/minimalisp/Lisp.java
+++ b/src/main/java/minimalisp/Lisp.java
@@ -220,15 +220,15 @@ public class Lisp {
    * Returns a new List of the results of applying the passed function to the
    * items in the list.
    */
-  public static <T, R> List<R> map(List<T> items, Function<T, R> func) {
+  public static <T, R> List<R> map(Function<T, R> func, List<T> items) {
     return items.stream().map(func).collect(Collectors.toList());
-  }
+  }  
 
   /**
    * Returns a Reduction of the results of applying the passed accumulator to
    * the items in the list.
    */
-  public static <T> T reduce(List<T> items, BinaryOperator<T> accumulator) {
+  public static <T> T reduce(BinaryOperator<T> accumulator, List<T> items) {
     return items.stream().reduce(accumulator).get();
   }
 
@@ -243,7 +243,7 @@ public class Lisp {
    * Returns a new list of the results of applying the predicate to the items in
    * the list.
    */
-  public static <T> List<T> filter(List<T> list, Predicate<T> predicate) {
+  public static <T> List<T> filter(Predicate<T> predicate, List<T> list) {
     return list.stream().filter(predicate).collect(Collectors.toList());
   }
 
@@ -265,20 +265,21 @@ public class Lisp {
    * Returns a new list the items in the list sorted by the natural order of the
    * results of applying the passed function to the items in the list.
    */
-  public static <T, R extends Comparable<R>> List<T> sortBy(List<T> list, Function<T, R> func) {
-    return sortBy(list, new Comparator<T>() {
-      public int compare(T o1, T o2) {
-        Comparator<R> c = Comparator.<R>naturalOrder();
-        return c.compare(func.apply(o1), func.apply(o2));
-      }
-    });
+  public static <T, R extends Comparable<R>> List<T> sortBy(Function<T, R> func, List<T> list) {
+    return sortBy(
+      new Comparator<T>() {
+        public int compare(T o1, T o2) {
+          return Comparator.<R>naturalOrder().compare(func.apply(o1), func.apply(o2));
+        }
+      }, 
+      list);
   }
   
   /**
    * Returns a new Map where the keys are the evaluated result from the block and the values
    * are arrays of elements in the collection that correspond to the key.
    */
-  public static <T, G> Map<G, List<T>> groupBy(List<T> list, Function<T, G> func) {
+  public static <T, G> Map<G, List<T>> groupBy(Function<T, G> func, List<T> list) {
     return list.stream().collect(Collectors.groupingBy(func));
   }
   
@@ -286,7 +287,7 @@ public class Lisp {
   /**
    * Returns a new list of items in the list sorted by the supplied comparator.
    */
-  public static <T> List<T> sortBy(List<T> list, Comparator<? super T> comparitor) {
+  public static <T> List<T> sortBy(Comparator<? super T> comparitor, List<T> list) {
     List<T> copy = copy(list);
     Collections.sort(copy, comparitor);
     return copy;

--- a/src/main/java/minimalisp/Lisp.java
+++ b/src/main/java/minimalisp/Lisp.java
@@ -21,74 +21,6 @@ import java.util.stream.IntStream;
  * 
  * Makes functional style programming easier in Java through easier list processing.
  * 
- * <p>Either have your class extend minimalisp.Lisp (if it's lisp processing it, statically import it's methods or use it directly (e.g. Lisp.list(1,2,3,4)).</p. 
- * 
- * <pre>{@code
- *  
- *     // FizzBuzz as:
- *     assertEquals(
- *        list("1", "2", "Fizz", "4", "Buzz", "Fizz", "7", "8", "Fizz", "Buzz", "11", "Fizz", "13", "14", "FizzBuzz", "16", "17", "Fizz", "19"), 
- *          map(range(1,20), i -> {
- *            if (i % 3 == 0 && i % 5 == 0) return "FizzBuzz";
- *            else if (i % 3 == 0) return "Fizz";
- *            else if (i % 5 == 0) return "Buzz";
- *            else return String.valueOf(i); }));
- * 
- *     // easy list creation
- *     List<String> letters = new ArrayList<String>();
- *     letters.add("A");
- *     letters.add("B");
- *     letters.add("C");
- *     letters.add("D");
- *     // becomes...
- *     assertEquals(letters, list("A", "B", "C", "D"));
- *     
- *     // easy array creation
- *     assertArrayEquals(new String[] {"A", "B", "C", "D"}, array("A", "B", "C", "D"));
- *     
- *     // easy map creation
- *     Map<String, String> expected = new HashMap<String, String>();
- *     expected.put("greeting", "Hey");
- *     expected.put("name", "Joe");
- *     // becomes...      
- *     assertEquals(expected, map("greeting", "Hey", "name", "Joe"));     
- * 
- *     // Transform lists to arrays and back again
- *     assertEquals(list("A", "B", "C", "D"), list(array("A", "B", "C", "D")));
- *     assertArrayEquals(array("A", "B", "C", "D"), array(list("A", "B", "C", "D")));
- *     assertEquals(map(1, "A", 2, "B"), invert(map("A", 1, "B", 2)));     
- *     
- *     // immutable reversing
- *     List<String> letters = list("A", "B", "C", "D");
- *     assertEquals(list("D", "C", "B", "A"), reverse(letters));
- *     assertEquals(list("A", "B", "C", "D"), letters);
- *
- *     // quick first and last items
- *     assertEquals("A", first(list("A", "B", "C", "D")));
- *     assertEquals("D", last(list("A", "B", "C", "D")));
- *     
- *     // compact away null values
- *     assertEquals(list("A", "B", "C", "D"), compact(list("A", null, null, "B", null, "C", null, "D")));
- *
- *     // flatten deep lists
- *     assertEquals(list("A", "B", "C", "D"), flatten(list(list("A", "B"), list("C", "D"))));
- *     
- *     // quick mapping and filtering 
- *     assertEquals(list("A", "B", "C", "D"), map(list("a", "b", "c", "d"), String::toUpperCase));     
- *     assertEquals(list(2, 4, 6), filter(list(1,2,3,4,5,6,7), i -> i % 2 == 0));
- *     
- *     // find unique values
- *     assertEquals(list("A", "B", "C", "D"), distinct(list("A", "B", "A", "B", "C", "C", "A", "D")));
- *     
- *     // sort by results of applied functions 
- *     assertEquals(
- *      list("The", "Fox", "the", "over", "lazy", "dogs", "Quick", "Brown", "Jumped"), 
- *      sortBy(
- *            list("The", "Quick", "Brown", "Fox", "Jumped", "over", "the", "lazy", "dogs"),
- *        String::length));    
- *     
- * </pre>
- * 
  * @author Craig Davidson
  *
  */
@@ -130,7 +62,7 @@ public class Lisp {
 
   /**
    * Returns a List of integers starting (inclusive) of the first number, and
-   * finishing (exlusive of the last).
+   * finishing (exclusive of the last).
    */
   public static List<Integer> range(int startInclusive, int endExclusive) {
     return IntStream.range(startInclusive, endExclusive).boxed().collect(Collectors.toList());
@@ -281,7 +213,6 @@ public class Lisp {
   public static <T, G> Map<G, List<T>> groupBy(Function<T, G> func, List<T> list) {
     return list.stream().collect(Collectors.groupingBy(func));
   }
-  
 
   /**
    * Returns a new list of items in the list sorted by the supplied comparator.

--- a/src/test/java/minimalisp/LispTest.java
+++ b/src/test/java/minimalisp/LispTest.java
@@ -154,17 +154,19 @@ public class LispTest extends Lisp {
   }
 
   @Test public void testMap() {
-    assertEquals(list("A", "B", "C", "D"), map(list("a", "b", "c", "d"), String::toUpperCase));
+    assertEquals(list("A", "B", "C", "D"), map(String::toUpperCase, list("a", "b", "c", "d")));
   }
 
   @Test public void testFizzBuzz() {
-    assertEquals(list("1", "2", "Fizz", "4", "Buzz", "Fizz", "7", "8", "Fizz", "Buzz", "11", "Fizz", "13", "14",
-        "FizzBuzz", "16", "17", "Fizz", "19"), map(range(1, 20), i -> {
-          if (i % 3 == 0 && i % 5 == 0) return "FizzBuzz";
-          else if (i % 3 == 0) return "Fizz";
-          else if (i % 5 == 0) return "Buzz";
-          else return String.valueOf(i);
-        }));
+    assertEquals(
+        list("1", "2", "Fizz", "4", "Buzz", "Fizz", "7", "8", "Fizz", "Buzz", "11", "Fizz", "13", "14", "FizzBuzz", "16", "17", "Fizz", "19"), 
+        map(
+          i -> {
+                 if (i % 3 == 0 && i % 5 == 0) return "FizzBuzz";
+                 else if (i % 3 == 0) return "Fizz";
+                 else if (i % 5 == 0) return "Buzz";
+                 else return String.valueOf(i);}, 
+          range(1, 20)));
   }
 
   @Test public void testRange() {
@@ -172,19 +174,19 @@ public class LispTest extends Lisp {
   }
 
   @Test public void testReduce() {
-    int reduced = reduce(list(1, 2, 3, 4, 5), (a, b) -> a + b);
+    int reduced = reduce((a, b) -> a + b, list(1, 2, 3, 4, 5));
     assertEquals(15, reduced);
 
-    double reducedDoubles = reduce(list(1.0, 2.0, 3.0, 4.0, 5.0), (a, b) -> a + b);
+    double reducedDoubles = reduce((a, b) -> a + b, list(1.0, 2.0, 3.0, 4.0, 5.0));
     assertEquals(15.0, reducedDoubles, 0);
   }
 
   @Test public void testSum() {
-    assertEquals(15, sum(map(list(1, 2, 3, 4, 5), BigDecimal::valueOf)).intValue());
+    assertEquals(15, sum(map(BigDecimal::valueOf, list(1, 2, 3, 4, 5))).intValue());
   }
 
   @Test public void testFilter() {
-    assertEquals(list(2, 4, 6), filter(list(1, 2, 3, 4, 5, 6, 7), i -> i % 2 == 0));
+    assertEquals(list(2, 4, 6), filter(i -> i % 2 == 0, list(1, 2, 3, 4, 5, 6, 7)));
   }
 
   @Test public void testDifference() {
@@ -198,14 +200,13 @@ public class LispTest extends Lisp {
 
   @Test public void testSortBy_withComparitor() {
     assertEquals(list("The", "Fox", "the", "over", "lazy", "dogs", "Quick", "Brown", "Jumped"),
-        sortBy(list("The", "Quick", "Brown", "Fox", "Jumped", "over", "the", "lazy", "dogs"),
-            (a, b) -> a.length() - b.length()));
+        sortBy((a, b) -> a.length() - b.length(), list("The", "Quick", "Brown", "Fox", "Jumped", "over", "the", "lazy", "dogs")));
   }
 
   @Test public void testSortBy_withFunction() {
     assertEquals(
         list("The", "Fox", "the", "over", "lazy", "dogs", "Quick", "Brown", "Jumped"),
-        sortBy(list("The", "Quick", "Brown", "Fox", "Jumped", "over", "the", "lazy", "dogs"), String::length));
+        sortBy(String::length, list("The", "Quick", "Brown", "Fox", "Jumped", "over", "the", "lazy", "dogs")));
   }
   
   @Test public void testGroupBy() {
@@ -216,7 +217,8 @@ public class LispTest extends Lisp {
           5, list("Quick", "Brown"), 
           6, list("Jumped")),
       groupBy(
-          list("The", "Quick", "Brown", "Fox", "Jumped", "over", "the", "lazy", "dogs"), 
-          String::length));
+          String::length, 
+          list("The", "Quick", "Brown", "Fox", "Jumped", "over", "the", "lazy", "dogs"))
+    );
   }
 }


### PR DESCRIPTION
Change function parameter order to be more inline with a regular Lisp,
so if we start with `(mapcar list)` then `(car list)` is generally the function and `(cdr list)` is the data.

To reflect that we should reverse our parameters so the function is always first.
i.e 
from: `filter(list, func)`
to: `filter(func, list)`

Impacts functions that take a function as a parameter: 
* map, reduce, filter, sortBy, groupBy
