### PR TITLE
Separate list into groups of specified number

### DIFF
--- a/src/main/java/minimalisp/Lisp.java
+++ b/src/main/java/minimalisp/Lisp.java
@@ -282,6 +282,23 @@ public class Lisp {
     return list.stream().collect(Collectors.groupingBy(func));
   }
   
+  public static <T> List<List<T>> inGroupsOf(int size, List<T> list){
+    List<List<T>> groups = new ArrayList<List<T>>();
+    List<T> group = new ArrayList<T>();
+    groups.add(group);
+    int count = 0;
+    for(T item : list){
+      if (count == size) {
+        group = new ArrayList<T>();
+        groups.add(group);
+        count = 0;
+      }
+      group.add(item);
+      count++;
+    }
+    return groups;    
+  }
+  
 
   /**
    * Returns a new list of items in the list sorted by the supplied comparator.

--- a/src/test/java/minimalisp/LispTest.java
+++ b/src/test/java/minimalisp/LispTest.java
@@ -219,4 +219,10 @@ public class LispTest extends Lisp {
           list("The", "Quick", "Brown", "Fox", "Jumped", "over", "the", "lazy", "dogs"), 
           String::length));
   }
+  
+  @Test public void testInGroupsOf() {
+    assertEquals(
+        list(list(1,2,3), list(4,5,6), list(7,8,9), list(10)),
+        inGroupsOf(3, range(1, 11)));
+  }
 }


### PR DESCRIPTION
Separate a provided list into sublist of specified size:

```
    assertEquals(
        list(list(1,2,3), list(4,5,6), list(7,8,9), list(10)),
        inGroupsOf(3, range(1, 11)));
```